### PR TITLE
Fix getDeviceId() on iOS

### DIFF
--- a/src/ios/BrazePlugin.m
+++ b/src/ios/BrazePlugin.m
@@ -435,7 +435,7 @@ static Braze *_braze;
 
 - (void)getDeviceId:(CDVInvokedUrlCommand *)command {
   NSString *deviceId = self.braze.deviceId;
-  [self sendCordovaErrorPluginResultWithString:deviceId andCommand:command];
+  [self sendCordovaSuccessPluginResultWithString:deviceId andCommand:command];
 }
 
 // MARK: - BrazeUI


### PR DESCRIPTION
The wrong method is being used to send the plugin result - this change makes it so that the plugin returns a successful result with the device ID.