### PR TITLE
fix: Remove duplicate Google Services plugin application

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -22,7 +22,9 @@ buildscript {
 // apply the google services plugin by its class name since we're not
 // in the root gradle file
 ext.postBuildExtras = {
-    apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+    if (!project.plugins.hasPlugin('com.google.gms.google-services')) {
+        apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+    }
 
     android {
         kotlinOptions {


### PR DESCRIPTION
Fixes build error: "Cannot add extension with name 'googleServices'"